### PR TITLE
feat(btc): on-demand note toggle for fund entries

### DIFF
--- a/src/components/btc/AddEntryDialog.tsx
+++ b/src/components/btc/AddEntryDialog.tsx
@@ -31,6 +31,7 @@ export function AddEntryDialog({
   const [mode, setMode] = useState<"native" | "usd">("native");
   const [amount, setAmount] = useState("");
   const [buyPrice, setBuyPrice] = useState(currentPrice.toString());
+  const [description, setDescription] = useState("");
 
   useEffect(() => {
     dialogRef.current?.showModal();
@@ -84,11 +85,16 @@ export function AddEntryDialog({
 
   const handleAdd = () => {
     if (!isValid) return;
+    const desc = description.trim() || undefined;
     if (mode === "native") {
-      onAdd({ amount });
+      onAdd({ amount, ...(desc ? { description: desc } : {}) });
     } else {
       const converted = (parsedAmount / parsedBuyPrice).toString();
-      onAdd({ amount: converted, buyPrice: parsedBuyPrice });
+      onAdd({
+        amount: converted,
+        buyPrice: parsedBuyPrice,
+        ...(desc ? { description: desc } : {}),
+      });
     }
   };
 
@@ -144,6 +150,18 @@ export function AddEntryDialog({
                 ? `${fund.ticker} amount`
                 : `USD amount for ${fund.ticker}`
             }
+          />
+        </label>
+        <label className="add-entry-dialog-label">
+          Note (optional)
+          <input
+            className="add-entry-dialog-input"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g. Coinbase purchase"
+            maxLength={200}
+            aria-label="Note for this entry"
           />
         </label>
         <div

--- a/src/components/btc/BtcPage.tsx
+++ b/src/components/btc/BtcPage.tsx
@@ -20,7 +20,11 @@ import { Footer } from "../Footer.tsx";
 
 type FundHandlers = Pick<
   FundInputProps,
-  "onEntryChange" | "onOpenAddDialog" | "onRemoveEntry" | "onConsolidate"
+  | "onEntryChange"
+  | "onDescriptionChange"
+  | "onOpenAddDialog"
+  | "onRemoveEntry"
+  | "onConsolidate"
 >;
 
 const LS_VISIBLE_KEY = "btc-visible-tickers";
@@ -82,15 +86,16 @@ export function BtcPage() {
   useEffect(() => {
     ALL_FUNDS.forEach((fund) => {
       const fundEntries = entries[fund.ticker] ?? [{ amount: "" }];
-      const toSave: { amount: string; buyPrice?: number }[] = [];
+      const toSave: { amount: string; buyPrice?: number; description?: string }[] =
+        [];
       for (const e of fundEntries) {
         const canonical = fund.toCanonical(e.amount, fund.nativeMode, prices);
         if (canonical === "" || parseFloat(canonical) === 0) continue;
-        toSave.push(
-          e.buyPrice != null
-            ? { amount: canonical, buyPrice: e.buyPrice }
-            : { amount: canonical },
-        );
+        const saved: { amount: string; buyPrice?: number; description?: string } =
+          { amount: canonical };
+        if (e.buyPrice != null) saved.buyPrice = e.buyPrice;
+        if (e.description) saved.description = e.description;
+        toSave.push(saved);
       }
       if (toSave.length > 0) {
         localStorage.setItem(fund.lsKey, JSON.stringify(toSave));
@@ -106,6 +111,20 @@ export function BtcPage() {
         ...prev,
         [ticker]: prev[ticker].map((e, i) =>
           i === index ? { ...e, amount: value } : e,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const handleDescriptionChange = useCallback(
+    (ticker: string, index: number, value: string) => {
+      setEntries((prev) => ({
+        ...prev,
+        [ticker]: prev[ticker].map((e, i) =>
+          i === index
+            ? { ...e, description: value || undefined }
+            : e,
         ),
       }));
     },
@@ -139,10 +158,23 @@ export function BtcPage() {
         const val = parseFloat(current[i].amount);
         return acc + (isNaN(val) ? 0 : val);
       }, 0);
+      const descriptions = indices
+        .map((i) => current[i].description)
+        .filter((d): d is string => Boolean(d));
+      const consolidatedDescription =
+        descriptions.length > 0 ? descriptions.join(" · ") : undefined;
       const kept = current.filter((_, i) => !indexSet.has(i));
       return {
         ...prev,
-        [ticker]: [{ amount: parseFloat(sum.toFixed(8)).toString() }, ...kept],
+        [ticker]: [
+          {
+            amount: parseFloat(sum.toFixed(8)).toString(),
+            ...(consolidatedDescription
+              ? { description: consolidatedDescription }
+              : {}),
+          },
+          ...kept,
+        ],
       };
     });
   }, []);
@@ -157,6 +189,8 @@ export function BtcPage() {
           {
             onEntryChange: (index: number, value: string) =>
               handleEntryChange(fund.ticker, index, value),
+            onDescriptionChange: (index: number, value: string) =>
+              handleDescriptionChange(fund.ticker, index, value),
             onOpenAddDialog: () => handleOpenAddDialog(fund.ticker),
             onRemoveEntry: (index: number) =>
               handleRemoveEntry(fund.ticker, index),
@@ -167,6 +201,7 @@ export function BtcPage() {
       ),
     [
       handleEntryChange,
+      handleDescriptionChange,
       handleOpenAddDialog,
       handleRemoveEntry,
       handleConsolidate,

--- a/src/components/btc/FundInput.tsx
+++ b/src/components/btc/FundInput.tsx
@@ -6,6 +6,7 @@ export interface FundInputProps {
   fund: FundConfig;
   entries: FundEntry[];
   onEntryChange: (index: number, value: string) => void;
+  onDescriptionChange: (index: number, value: string) => void;
   onOpenAddDialog: () => void;
   onRemoveEntry: (index: number) => void;
   onConsolidate: (indices: number[]) => void;
@@ -15,16 +16,40 @@ export const FundInput = memo(function FundInput({
   fund,
   entries,
   onEntryChange,
+  onDescriptionChange,
   onOpenAddDialog,
   onRemoveEntry,
   onConsolidate,
 }: FundInputProps) {
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [noteOpen, setNoteOpen] = useState<Set<number>>(new Set());
 
-  // Reset selection when entries length changes (rows added/removed/consolidated)
   useEffect(() => {
     setSelected((prev) => (prev.size === 0 ? prev : new Set()));
+    setNoteOpen((prev) => (prev.size === 0 ? prev : new Set()));
   }, [entries.length]);
+
+  const toggleNote = (index: number) => {
+    setNoteOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  const closeNoteIfEmpty = (index: number, value: string) => {
+    if (!value) {
+      setNoteOpen((prev) => {
+        const next = new Set(prev);
+        next.delete(index);
+        return next;
+      });
+    }
+  };
 
   const toggleSelected = (index: number) => {
     setSelected((prev) => {
@@ -50,43 +75,68 @@ export const FundInput = memo(function FundInput({
     <div className={`btc-input-group btc-input-group--${fund.cssModifier}`}>
       <div className="btc-label">{fund.label}</div>
       {entries.map((entry, i) => (
-        <div className="btc-input-row" key={i}>
-          {showCheckboxes && (
+        <div className="btc-entry-wrap" key={i}>
+          <div className="btc-input-row">
+            {showCheckboxes && (
+              <input
+                type="checkbox"
+                className="btc-entry-checkbox"
+                checked={selected.has(i)}
+                onChange={() => toggleSelected(i)}
+                aria-label={`Select ${fund.ticker} entry ${i + 1}`}
+              />
+            )}
+            <span className="btc-input-prefix">{fund.nativePrefix}</span>
             <input
-              type="checkbox"
-              className="btc-entry-checkbox"
-              checked={selected.has(i)}
-              onChange={() => toggleSelected(i)}
-              aria-label={`Select ${fund.ticker} entry ${i + 1}`}
+              className="btc-input"
+              type="text"
+              inputMode="decimal"
+              name={`${fund.cssModifier}-${i}`}
+              value={entry.amount}
+              onChange={(e) =>
+                onEntryChange(i, sanitizeNumericInput(e.target.value))
+              }
+              placeholder={fund.nativePlaceholder}
+              aria-label={`${fund.nativeAriaLabel} ${i + 1}`}
+            />
+            {entry.buyPrice != null && (
+              <span className="btc-entry-buy-price">
+                @ {formatUsd(entry.buyPrice)}
+              </span>
+            )}
+            <button
+              className={`btc-note-toggle${noteOpen.has(i) || entry.description ? " btc-note-toggle--active" : ""}`}
+              onClick={() => {
+                toggleNote(i);
+              }}
+              aria-label={`${noteOpen.has(i) ? "Hide" : "Show"} note for ${fund.ticker} entry ${i + 1}`}
+              title="Add note"
+            >
+              <i className="fa-regular fa-note-sticky" />
+            </button>
+            <button
+              className="btc-entry-remove"
+              onClick={() =>
+                entries.length > 1 ? onRemoveEntry(i) : onEntryChange(i, "")
+              }
+              aria-label={`Remove ${fund.ticker} entry ${i + 1}`}
+            >
+              ×
+            </button>
+          </div>
+          {(noteOpen.has(i) || !!entry.description) && (
+            <input
+              className="btc-entry-description"
+              type="text"
+              value={entry.description ?? ""}
+              onChange={(e) => onDescriptionChange(i, e.target.value)}
+              onBlur={(e) => closeNoteIfEmpty(i, e.target.value)}
+              placeholder="add note..."
+              maxLength={200}
+              autoFocus={noteOpen.has(i) && !entry.description}
+              aria-label={`Note for ${fund.ticker} entry ${i + 1}`}
             />
           )}
-          <span className="btc-input-prefix">{fund.nativePrefix}</span>
-          <input
-            className="btc-input"
-            type="text"
-            inputMode="decimal"
-            name={`${fund.cssModifier}-${i}`}
-            value={entry.amount}
-            onChange={(e) =>
-              onEntryChange(i, sanitizeNumericInput(e.target.value))
-            }
-            placeholder={fund.nativePlaceholder}
-            aria-label={`${fund.nativeAriaLabel} ${i + 1}`}
-          />
-          {entry.buyPrice != null && (
-            <span className="btc-entry-buy-price">
-              @ {formatUsd(entry.buyPrice)}
-            </span>
-          )}
-          <button
-            className="btc-entry-remove"
-            onClick={() =>
-              entries.length > 1 ? onRemoveEntry(i) : onEntryChange(i, "")
-            }
-            aria-label={`Remove ${fund.ticker} entry ${i + 1}`}
-          >
-            x
-          </button>
         </div>
       ))}
       {canConsolidate && (

--- a/src/lib/btc.ts
+++ b/src/lib/btc.ts
@@ -96,8 +96,22 @@ export function parseStoredEntries(raw: string | null): FundEntry[] {
   try {
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed) && parsed.length > 0) {
-      // New FundEntry[] format: [{amount, buyPrice?}, ...]
-      if (typeof parsed[0] === "object" && parsed[0] !== null) return parsed;
+      // New FundEntry[] format: [{amount, buyPrice?, description?}, ...]
+      if (typeof parsed[0] === "object" && parsed[0] !== null) {
+        return parsed.map((e: unknown): FundEntry => {
+          if (typeof e !== "object" || e === null) return { amount: "" };
+          const entry = e as Record<string, unknown>;
+          return {
+            amount: typeof entry.amount === "string" ? entry.amount : "",
+            ...(typeof entry.buyPrice === "number"
+              ? { buyPrice: entry.buyPrice }
+              : {}),
+            ...(typeof entry.description === "string" && entry.description
+              ? { description: entry.description.slice(0, 200) }
+              : {}),
+          };
+        });
+      }
       // Legacy string[] format: ["1.5", "2"] -> [{amount: "1.5"}, {amount: "2"}]
       return parsed.map((s: string) => ({ amount: s }));
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface BtcPrices {
 export interface FundEntry {
   amount: string;
   buyPrice?: number;
+  description?: string;
 }
 
 export type FundMode = "btc" | "shares" | "usd";

--- a/src/styles/btc.less
+++ b/src/styles/btc.less
@@ -305,8 +305,75 @@
   border-radius: @radius-sm;
 }
 
-.btc-input-row + .btc-input-row {
+.btc-entry-wrap + .btc-entry-wrap {
   margin-top: @spacing-sm;
+}
+
+.btc-note-toggle {
+  background: none;
+  border: none;
+  color: @muted-dark;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: @spacing-xxs @spacing-xs;
+  margin: 0;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+
+  i {
+    line-height: 0;
+    display: block;
+  }
+
+  &:hover {
+    color: @muted;
+  }
+
+  &--active {
+    color: var(--accent);
+
+    &:hover {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+  }
+}
+
+.btc-entry-description {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: @muted;
+  font-family: inherit;
+  font-size: 0.78rem;
+  padding: @spacing-xs @spacing-md;
+  outline: none;
+  box-sizing: border-box;
+  animation: note-fade-in 0.15s ease-out;
+
+  &::placeholder {
+    color: @muted-dark;
+  }
+
+  &:focus {
+    color: @light-text;
+  }
+}
+
+@keyframes note-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .btc-entry-buy-price {
@@ -324,8 +391,10 @@
   cursor: pointer;
   padding: @spacing-xxs @spacing-sm;
   margin: 0;
-  margin-top: 0;
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: color 0.2s;
 
   &:hover {


### PR DESCRIPTION
Replace always-visible note field with a sticky-note icon button per entry. The note input renders only when toggled open or when it has content, collapsing on blur if empty. Icon highlights in accent color when active.

<img width="431" height="362" alt="image" src="https://github.com/user-attachments/assets/0fbd445e-7aad-4607-b644-29c1d8a75605" />
